### PR TITLE
Split bb parser into two stages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 vendor
+
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Tags must extend the `\CsrDelft\bb\BbTag` class. Tags must implement the `parse(
 
 The `getTagName` method retuns a string or list of strings with the name(s) of this tag.
 
-The `parse` method receives a map of arguments. The `getContent` method can be used to retrieve the contents of
+The `parse` method receives a map of arguments. The `readContent` method can be used to retrieve the contents of
 the tag, this content is parsed by the parser when it is received. The parser reads the input until an end tag is
-found. `getContent` has an optional parameter for tags which are forbidden to be in this tag. For instance a `[sup]`
+found. `readContent` has an optional parameter for tags which are forbidden to be in this tag. For instance a `[sup]`
 tag cannot contain another sup tag or a sub tag.
 
 A tag has access to an environment, which is by default of type `CsrDelft\bb\BBenv` (can be overridden).
@@ -73,11 +73,11 @@ class BbSuperscript extends BbTag {
 	}
 
 	public function render() {
-		return '<sup class="bb-tag-sup">' . $this->content . '</sup>';
+		return '<sup class="bb-tag-sup">' . $this->getContent() . '</sup>';
 	}
     
     public function parse($arguments = []) {
-         $this->readContent(['sub', 'sup'])
+         $this->readContent(['sub', 'sup']);
        }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
   },
   "autoload": {
     "psr-4": {
-      "CsrDelft\\bb\\": "src/"
+      "CsrDelft\\bb\\": "src/",
+      "CsrDelft\\bb\\test\\": "tests/lib/"
     }
   },
   "scripts": {

--- a/src/BbTag.php
+++ b/src/BbTag.php
@@ -21,7 +21,7 @@ abstract class BbTag implements Node {
      * The content of the tag. Is empty at parse time. Can be filled by calling readContent()
      * @var string|null
      */
-    protected $content = null;
+    private $content = null;
 
     public function setParser(Parser $parser) {
         $this->parser = $parser;

--- a/src/BbTag.php
+++ b/src/BbTag.php
@@ -24,7 +24,6 @@ abstract class BbTag implements BbNode
      * @var string|null
      */
     private $content = null;
-    private $arguments;
     /**
      * @var BbNode[]|null
      */
@@ -104,16 +103,6 @@ abstract class BbTag implements BbNode
     public function renderPlain()
     {
         return strip_tags($this->render());
-    }
-
-    public function getArguments()
-    {
-        return $this->arguments;
-    }
-
-    public function setArguments($arguments)
-    {
-        $this->arguments = $arguments;
     }
 
     /**

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -151,7 +151,7 @@ abstract class Parser {
             return null;
         }
 
-        $blocks = $this->parse($bbcode);
+        $blocks = $this->parseString($bbcode);
 
         $html = $this->render($blocks, $this->env->mode);
 
@@ -164,7 +164,7 @@ abstract class Parser {
      * @param string $bbcode
      * @return Node[]|null
      */
-    public function parse($bbcode) {
+    public function parseString($bbcode) {
         if ($this->env->mode !== "plain") {
             $bbcode = str_replace(array("\r\n", "\n"), self::BR_TAG, $bbcode);
         }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -369,7 +369,6 @@ abstract class Parser {
                     $this->level++;
                     try {
                         $tagInstance->parse($arguments);
-                        $tagInstance->setArguments($arguments);
                     } catch (BbException $ex) {
                         $tagInstance = new BbError($ex->getMessage());
                     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -2,6 +2,10 @@
 
 namespace CsrDelft\bb;
 
+use CsrDelft\bb\internal\BbError;
+use CsrDelft\bb\internal\BbString;
+use CsrDelft\bb\tag\Node;
+
 /**
  * Main BB-code Parser file
  *
@@ -24,6 +28,8 @@ abstract class Parser {
      *    [3] => [/b]
      *    [4] => , cool huh?!
      *      )
+     *
+     * @var string[]
      */
     public $parseArray = array();
     /**
@@ -145,23 +151,66 @@ abstract class Parser {
             return null;
         }
 
-        if ($this->env->mode === "plain") {
-            $this->bbcode = $bbcode;
-        } else {
-            $this->bbcode = str_replace(array("\r\n", "\n"), self::BR_TAG, $bbcode);
+        $blocks = $this->parse($bbcode);
+
+        $html = $this->render($blocks, $this->env->mode);
+
+        $this->HTML = str_replace(self::BR_TAG, "<br />\n", $html);
+
+        return $this->HTML;
+    }
+
+    /**
+     * @param string $bbcode
+     * @return Node[]|null
+     */
+    public function parse($bbcode) {
+        if ($this->env->mode !== "plain") {
+            $bbcode = str_replace(array("\r\n", "\n"), self::BR_TAG, $bbcode);
         }
 
         // Create the parsearray with the buildarray function, pretty nice ;)
         $this->tags_counted = 0;
-        $this->parseArray = $this->tokenize($this->bbcode);
+        $this->parseArray = $this->tokenize($bbcode);
 
         // Fix html rights
         $this->htmlFix();
 
-        // Get output
-        $this->HTML = str_replace(self::BR_TAG, "<br />\n", $this->parseArray());
+        return $this->parseArray();
+    }
 
-        return $this->HTML;
+    /**
+     * Renders a Node[] to a string.
+     *
+     * @param Node[] $blocks
+     * @param string $mode
+     * @return string
+     */
+    public function render($blocks, $mode)
+    {
+        if (empty($blocks)) {
+            return '';
+        }
+
+        $text = '';
+
+        foreach ($blocks as $block) {
+            if ($block->isAllowed()) {
+                $block->setContent($this->render($block->getChildren(), $mode));
+
+                if ($mode == "light") {
+                    $text .= $block->renderLight();
+                } elseif ($mode == "plain") {
+                    $text .= $block->renderPlain();
+                } else {
+                    $text .= $block->render();
+                }
+            } else {
+                $text .= '';
+            }
+    }
+
+        return $text;
     }
 
     private function tokenize($str) {
@@ -253,14 +302,14 @@ abstract class Parser {
      * Walks through the array until one of the stoppers is found. When encountering an 'open' tag, which is not in $forbidden, open corresponding bb_ function.
      * @param array $stoppers
      * @param array $forbidden
-     * @return string|null
+     * @return Node[]
      */
     public function parseArray($stoppers = [], $forbidden = []) {
 
         if (!is_array($this->parseArray)) { // Well, nothing to parse
             return null;
         }
-        $text = '';
+        $blocks = [];
 
         $forbidden_aantal_open = 0;
         while ($entry = array_shift($this->parseArray)) {
@@ -270,10 +319,10 @@ abstract class Parser {
                 if ($forbidden_aantal_open == 0) {
 
                     $this->level--;
-                    return $text;
+                    return $blocks;
                 } else {
                     $forbidden_aantal_open--;
-                    $text .= $entry;
+                    $blocks[] = new BbString($entry);
                 }
             } else {
 
@@ -318,30 +367,18 @@ abstract class Parser {
                     }
 
                     $this->level++;
-                    $newtext = null;
                     try {
                         $tagInstance->parse($arguments);
-                        if ($tagInstance->isAllowed()) {
-                            if ($this->env->mode == "light") {
-                                $newtext = $tagInstance->renderLight();
-                            } elseif ($this->env->mode == "plain") {
-                                $newtext = $tagInstance->renderPlain();
-                            } else {
-                                $newtext = $tagInstance->render();
-                            }
-                        }
-                        else {
-                            $newtext = '';
-                        }
                     } catch (BbException $ex) {
-                        $newtext = $ex->getMessage();
+                        $tagInstance = new BbError($ex->getMessage());
                     }
 
                     // Reset paragraph_required.
-                    if ($this->paragraph_mode && $paragraph_setting_modified)
+                    if ($this->paragraph_mode && $paragraph_setting_modified) {
                         $this->paragraph_required = true;
+                    }
 
-                    $text .= $newtext;
+                    $blocks[] = $tagInstance;
                 } else {
 
                     if ($this->paragraph_mode && $entry == self::BR_TAG) {
@@ -394,17 +431,17 @@ abstract class Parser {
                         $this->paragraph_open = true;
                     }
 
-                    $text .= $entry;
+                    $blocks[] = new BbString($entry);
                 }
             }
         } // End of BIG while!
 
         if ($this->paragraph_open) { // No need for a level check, should be zero anyway.
             $this->paragraph_open = false;
-            $text .= '</p>';
+            $blocks[] = new BbString("</p>");
         }
 
-        return $text;
+        return $blocks;
     }
 
     /**

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -4,7 +4,7 @@ namespace CsrDelft\bb;
 
 use CsrDelft\bb\internal\BbError;
 use CsrDelft\bb\internal\BbString;
-use CsrDelft\bb\tag\Node;
+use CsrDelft\bb\tag\BbNode;
 
 /**
  * Main BB-code Parser file
@@ -162,7 +162,7 @@ abstract class Parser {
 
     /**
      * @param string $bbcode
-     * @return Node[]|null
+     * @return BbNode[]|null
      */
     public function parseString($bbcode) {
         if ($this->env->mode !== "plain") {
@@ -182,7 +182,7 @@ abstract class Parser {
     /**
      * Renders a Node[] to a string.
      *
-     * @param Node[] $blocks
+     * @param BbNode[] $blocks
      * @param string $mode
      * @return string
      */
@@ -302,7 +302,7 @@ abstract class Parser {
      * Walks through the array until one of the stoppers is found. When encountering an 'open' tag, which is not in $forbidden, open corresponding bb_ function.
      * @param array $stoppers
      * @param array $forbidden
-     * @return Node[]
+     * @return BbNode[]
      */
     public function parseArray($stoppers = [], $forbidden = []) {
 
@@ -369,6 +369,7 @@ abstract class Parser {
                     $this->level++;
                     try {
                         $tagInstance->parse($arguments);
+                        $tagInstance->setArguments($arguments);
                     } catch (BbException $ex) {
                         $tagInstance = new BbError($ex->getMessage());
                     }

--- a/src/internal/BbError.php
+++ b/src/internal/BbError.php
@@ -52,9 +52,4 @@ class BbError implements BbNode
     {
         return $this->render();
     }
-
-    public function getArguments()
-    {
-        return [];
-    }
 }

--- a/src/internal/BbError.php
+++ b/src/internal/BbError.php
@@ -4,9 +4,9 @@
 namespace CsrDelft\bb\internal;
 
 
-use CsrDelft\bb\tag\Node;
+use CsrDelft\bb\tag\BbNode;
 
-class BbError implements Node
+class BbError implements BbNode
 {
     /**
      * @var string
@@ -51,5 +51,10 @@ class BbError implements Node
     public function renderLight()
     {
         return $this->render();
+    }
+
+    public function getArguments()
+    {
+        return [];
     }
 }

--- a/src/internal/BbError.php
+++ b/src/internal/BbError.php
@@ -1,0 +1,55 @@
+<?php
+
+
+namespace CsrDelft\bb\internal;
+
+
+use CsrDelft\bb\tag\Node;
+
+class BbError implements Node
+{
+    /**
+     * @var string
+     */
+    private $error;
+
+    public function __construct(string $error)
+    {
+        $this->error = $error;
+    }
+
+    public function isAllowed()
+    {
+        return true;
+    }
+
+    public function render()
+    {
+        return $this->error;
+    }
+
+    public function getChildren()
+    {
+        return [];
+    }
+
+    public function setContent($content)
+    {
+        // Nop
+    }
+
+    public function getContent()
+    {
+        return null;
+    }
+
+    public function renderPlain()
+    {
+        return $this->render();
+    }
+
+    public function renderLight()
+    {
+        return $this->render();
+    }
+}

--- a/src/internal/BbString.php
+++ b/src/internal/BbString.php
@@ -3,9 +3,9 @@
 
 namespace CsrDelft\bb\internal;
 
-use CsrDelft\bb\tag\Node;
+use CsrDelft\bb\tag\BbNode;
 
-class BbString implements Node
+class BbString implements BbNode
 {
     /**
      * @var string
@@ -50,5 +50,10 @@ class BbString implements Node
     public function renderLight()
     {
         return $this->render();
+    }
+
+    public function getArguments()
+    {
+        return [];
     }
 }

--- a/src/internal/BbString.php
+++ b/src/internal/BbString.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace CsrDelft\bb\internal;
+
+use CsrDelft\bb\tag\Node;
+
+class BbString implements Node
+{
+    /**
+     * @var string
+     */
+    private $string;
+
+    public function __construct(string $string)
+    {
+        $this->string = $string;
+    }
+
+    public function isAllowed()
+    {
+        return true;
+    }
+
+    public function render()
+    {
+        return $this->string;
+    }
+
+    public function getChildren()
+    {
+        return [];
+    }
+
+    public function setContent($content)
+    {
+        // Nop
+    }
+
+    public function getContent()
+    {
+        return $this->string;
+    }
+
+    public function renderPlain()
+    {
+        return $this->render();
+    }
+
+    public function renderLight()
+    {
+        return $this->render();
+    }
+}

--- a/src/internal/BbString.php
+++ b/src/internal/BbString.php
@@ -51,9 +51,4 @@ class BbString implements BbNode
     {
         return $this->render();
     }
-
-    public function getArguments()
-    {
-        return [];
-    }
 }

--- a/src/tag/BbBold.php
+++ b/src/tag/BbBold.php
@@ -9,27 +9,32 @@ use CsrDelft\bb\BbTag;
  * @since 27/03/2019
  */
 class BbBold extends BbTag {
+    private $disabled = false;
+
 	public static function getTagName() {
 		return 'b';
 	}
 
     public function parse($arguments = []) {
+	    if ($this->env->nobold === true && $this->env->quote_level == 0) {
+	        $this->disabled = true;
+        }
         $this->readContent();
     }
 
     public function renderPlain() {
-        if ($this->env->nobold === true && $this->env->quote_level == 0) {
-            return $this->content;
+        if ($this->disabled) {
+            return $this->getContent();
         } else {
-            return '*' . $this->content . '*';
+            return '*' . $this->getContent() . '*';
         }
     }
 
     public function render() {
-		if ($this->env->nobold === true && $this->env->quote_level == 0) {
-			return $this->content;
+		if ($this->disabled) {
+			return $this->getContent();
 		} else {
-			return '<strong class="dikgedrukt bb-tag-b">' . $this->content . '</strong>';
+			return '<strong class="dikgedrukt bb-tag-b">' . $this->getContent() . '</strong>';
 		}
 	}
 }

--- a/src/tag/BbCode.php
+++ b/src/tag/BbCode.php
@@ -30,10 +30,10 @@ class BbCode extends BbTag {
     }
 
     public function renderPlain() {
-        return "$this->code\n\t" . str_replace("\n", "\n\t", $this->content);
+        return "$this->code\n\t" . str_replace("\n", "\n\t", $this->getContent());
     }
 
     public function render() {
-		return '<div class="bb-tag-code"><sub>' . $this->code . 'code:</sub><pre class="bbcode">' . $this->content . '</pre></div>';
+		return '<div class="bb-tag-code"><sub>' . $this->code . 'code:</sub><pre class="bbcode">' . $this->getContent() . '</pre></div>';
 	}
 }

--- a/src/tag/BbDiv.php
+++ b/src/tag/BbDiv.php
@@ -26,6 +26,10 @@ class BbDiv extends BbTag {
      * @var string
      */
     private $style;
+    /**
+     * @var string
+     */
+    private $title;
 
     public static function getTagName() {
 		return 'div';
@@ -64,6 +68,6 @@ class BbDiv extends BbTag {
     }
 
 	public function render($arguments = []) {
-		return '<div' . $this->class . $this->style . $this->title . '>' . $this->content . '</div>';
+		return '<div' . $this->class . $this->style . $this->title . '>' . $this->getContent() . '</div>';
 	}
 }

--- a/src/tag/BbHeading.php
+++ b/src/tag/BbHeading.php
@@ -48,13 +48,13 @@ class BbHeading extends BbTag {
 
 	public function render() {
 		$id = $this->id == null ? '' : ' id="' . htmlspecialchars($this->id) . '"';
-		$text = "<h$this->heading_level$id class=\"bb-tag-h\">$this->content</h$this->heading_level>\n\n";
+		$text = "<h$this->heading_level$id class=\"bb-tag-h\">{$this->getContent()}</h$this->heading_level>\n\n";
 		return $text;
 	}
 
 	public function renderPlain() {
-        $lines = explode("\n", $this->content);
-        return $this->content . "\n" . str_repeat("-", strlen(end($lines)));
+        $lines = explode("\n", $this->getContent());
+        return $this->getContent() . "\n" . str_repeat("-", strlen(end($lines)));
     }
 
     public static function isParagraphLess() {

--- a/src/tag/BbHorizontalRule.php
+++ b/src/tag/BbHorizontalRule.php
@@ -31,5 +31,6 @@ class BbHorizontalRule extends BbTag {
 
     public function parse($arguments = [])
     {
+        // No arguments
     }
 }

--- a/src/tag/BbItalic.php
+++ b/src/tag/BbItalic.php
@@ -14,11 +14,11 @@ class BbItalic extends BbTag {
 	}
 
 	public function render() {
-		return '<em class="cursief bb-tag-i">' . $this->content . '</em>';
+		return '<em class="cursief bb-tag-i">' . $this->getContent() . '</em>';
 	}
 
 	public function renderPlain() {
-        return "_" . $this->content . "_";
+        return "_" . $this->getContent() . "_";
     }
 
     public function parse($arguments = [])

--- a/src/tag/BbLeet.php
+++ b/src/tag/BbLeet.php
@@ -15,7 +15,7 @@ class BbLeet extends BbTag {
 	}
 
 	public function render() {
-		$html = $this->content;
+		$html = $this->getContent();
 		$html = str_replace('er ', '0r ', $html);
 		$html = str_replace('you', 'j00', $html);
 		$html = str_replace('elite', '1337', $html);

--- a/src/tag/BbLishort.php
+++ b/src/tag/BbLishort.php
@@ -19,11 +19,11 @@ class BbLishort extends BbTag {
 	}
 
 	public function render() {
-		return '<li class="bb-tag-li">' . $this->content . '</li>';
+		return '<li class="bb-tag-li">' . $this->getContent() . '</li>';
 	}
 
 	public function renderPlain() {
-        return " * " . $this->content;
+        return " * " . $this->getContent();
     }
 
     public function parse($arguments = [])

--- a/src/tag/BbLishort.php
+++ b/src/tag/BbLishort.php
@@ -28,6 +28,6 @@ class BbLishort extends BbTag {
 
     public function parse($arguments = [])
     {
-        $this->content = $this->parser->parseArray(['[br]']);
+        $this->setChildren($this->parser->parseArray(['[br]']));
     }
 }

--- a/src/tag/BbList.php
+++ b/src/tag/BbList.php
@@ -24,10 +24,11 @@ class BbList extends BbTag {
 	}
 
 	public function render() {
-        if ($this->type == null)
-            return "<ul class=\"bb-tag-list\">" . $this->content . '</ul>';
-        else
-            return "<ol class=\"bb-tag-list\" \"type=\"$this->type\" >" . $this->content . '</ol>';
+        if ($this->type == null) {
+            return "<ul class=\"bb-tag-list\">{$this->getContent()}</ul>";
+        } else {
+            return "<ol class=\"bb-tag-list\" \"type=\"$this->type\" >{$this->getContent()}</ol>";
+        }
 
 	}
 

--- a/src/tag/BbListItem.php
+++ b/src/tag/BbListItem.php
@@ -18,11 +18,11 @@ class BbListItem extends BbTag{
 	}
 
 	public function render() {
-		return '<li class="bb-tag-li">' . $this->content . '</li>';
+		return '<li class="bb-tag-li">' . $this->getContent() . '</li>';
 	}
 
 	public function renderPlain() {
-        return " * " . $this->content;
+        return " * " . $this->getContent();
     }
 
     public function parse($arguments = [])

--- a/src/tag/BbMe.php
+++ b/src/tag/BbMe.php
@@ -24,16 +24,15 @@ class BbMe extends BbTag {
 
 	public function render($arguments = []) {
 		if ($this->name != null) {
-			return '<span style="color:red;">* ' . $this->name . $this->content . '</span>';
+			return '<span style="color:red;">* ' . $this->name . $this->getContent() . '</span>';
 		} else {
-			return '<span style="color:red;">/me' . $this->content . '</span>';
+			return '<span style="color:red;">/me' . $this->getContent() . '</span>';
 		}
 	}
 
     public function parse($arguments = [])
     {
-
-        $this->content = $this->parser->parseArray(['[br]']);
+        $this->setChildren($this->parser->parseArray(['[br]']));
         array_unshift($this->parser->parseArray, '[br]');
         $this->name = $arguments['me'] ?? null;
     }

--- a/src/tag/BbNewline.php
+++ b/src/tag/BbNewline.php
@@ -24,5 +24,6 @@ class BbNewline extends BbTag {
 
     public function parse($arguments = [])
     {
+        // No arguments
     }
 }

--- a/src/tag/BbNobold.php
+++ b/src/tag/BbNobold.php
@@ -14,13 +14,13 @@ class BbNobold extends BbTag {
 	}
 
 	public function render($arguments = []) {
-		$this->env->nobold = true;
-		$return = $this->readContent();
-		$this->env->nobold = false;
-		return $return;
+		return $this->getContent();
 	}
 
     public function parse($arguments = [])
     {
+        $this->env->nobold = true;
+        $this->readContent();
+        $this->env->nobold = false;
     }
 }

--- a/src/tag/BbNode.php
+++ b/src/tag/BbNode.php
@@ -4,7 +4,7 @@
 namespace CsrDelft\bb\tag;
 
 
-interface Node
+interface BbNode
 {
     public function renderPlain();
     public function renderLight();
@@ -15,4 +15,6 @@ interface Node
     public function getContent();
 
     public function isAllowed();
+
+    public function getArguments();
 }

--- a/src/tag/BbNode.php
+++ b/src/tag/BbNode.php
@@ -6,15 +6,39 @@ namespace CsrDelft\bb\tag;
 
 interface BbNode
 {
+    /**
+     * @return string
+     */
     public function renderPlain();
+
+    /**
+     * @return string
+     */
     public function renderLight();
+
+    /**
+     * @return string
+     */
     public function render();
+
+    /**
+     * @return BbNode[]
+     */
     public function getChildren();
 
+    /**
+     * @param string $content
+     * @return void
+     */
     public function setContent($content);
+
+    /**
+     * @return void
+     */
     public function getContent();
 
+    /**
+     * @return bool
+     */
     public function isAllowed();
-
-    public function getArguments();
 }

--- a/src/tag/BbQuote.php
+++ b/src/tag/BbQuote.php
@@ -3,6 +3,7 @@
 namespace CsrDelft\bb\tag;
 
 use CsrDelft\bb\BbTag;
+use CsrDelft\bb\internal\BbString;
 
 /**
  * Quote
@@ -17,12 +18,12 @@ class BbQuote extends BbTag {
 	}
 
 	public function renderPlain() {
-        return "> " . str_replace("\n", "\n> ", $this->content);
+        return "> " . str_replace("\n", "\n> ", $this->getContent());
     }
 
     public function render($arguments = []) {
 		return '<div class="citaatContainer bb-tag-quote"><strong>Citaat</strong>' .
-			'<div class="citaat">' . $this->content . '</div></div>';
+			'<div class="citaat">' . $this->getContent() . '</div></div>';
 	}
 
 	public static function isParagraphLess() {
@@ -39,7 +40,7 @@ class BbQuote extends BbTag {
             $this->env->quote_level++;
             $this->readContent();
             $this->env->quote_level--;
-            $this->content = '...';
+            $this->setChildren([new BbString("...")]);
         }
     }
 }

--- a/src/tag/BbStrikethrough.php
+++ b/src/tag/BbStrikethrough.php
@@ -15,11 +15,11 @@ class BbStrikethrough extends BbTag {
 	}
 
 	public function render($arguments = []) {
-		return '<del class="doorstreept bb-tag-s">' . $this->content . '</del>';
+		return '<del class="doorstreept bb-tag-s">' . $this->getContent() . '</del>';
 	}
 
 	public function renderPlain() {
-        return "~" . $this->content . "~";
+        return "~" . $this->getContent() . "~";
     }
 
     public function parse($arguments = [])

--- a/src/tag/BbSubscript.php
+++ b/src/tag/BbSubscript.php
@@ -18,7 +18,7 @@ class BbSubscript extends BbTag {
 	}
 
 	public function render($arguments = []) {
-		return '<sub class="bb-tag-sub">' . $this->content . '</sub>';
+		return '<sub class="bb-tag-sub">' . $this->getContent() . '</sub>';
 	}
 
     public function parse($arguments = [])

--- a/src/tag/BbSuperscript.php
+++ b/src/tag/BbSuperscript.php
@@ -18,7 +18,7 @@ class BbSuperscript extends BbTag {
 	}
 
 	public function render($arguments = []) {
-		return '<sup class="bb-tag-sup">' . $this->content . '</sup>';
+		return '<sup class="bb-tag-sup">' . $this->getContent() . '</sup>';
 	}
 
     public function parse($arguments = [])

--- a/src/tag/BbTable.php
+++ b/src/tag/BbTable.php
@@ -28,7 +28,7 @@ class BbTable extends BbTag {
 		    $style .= $name . ': ' . str_replace('_', ' ', htmlspecialchars($value)) . '; ';
 		}
 
-		return '<table class="bb-table bb-tag-table" style="' . $style . '">' . $this->content . '</table>';
+		return '<table class="bb-table bb-tag-table" style="' . $style . '">' . $this->getContent() . '</table>';
 	}
 
 	public static function isParagraphLess() {

--- a/src/tag/BbTableCell.php
+++ b/src/tag/BbTableCell.php
@@ -26,7 +26,7 @@ class BbTableCell extends BbTag {
 			$style .= 'width: ' . (int)$this->width . 'px; ';
 		}
 
-		return '<td class="bb-tag-td" style="' . $style . '">' . $this->content . '</td>';
+		return '<td class="bb-tag-td" style="' . $style . '">' . $this->getContent() . '</td>';
 	}
 
     public function parse($arguments = [])

--- a/src/tag/BbTableHeader.php
+++ b/src/tag/BbTableHeader.php
@@ -17,7 +17,7 @@ class BbTableHeader extends BbTag {
 	}
 
 	public function render($arguments = []) {
-		return '<th class="bb-tag-th">' . $this->content . '</th>';
+		return '<th class="bb-tag-th">' . $this->getContent() . '</th>';
 	}
 
     public function parse($arguments = [])

--- a/src/tag/BbTableRow.php
+++ b/src/tag/BbTableRow.php
@@ -19,7 +19,7 @@ class BbTableRow extends BbTag {
 	}
 
 	public function render($arguments = []) {
-		return '<tr class="bb-tag-tr">' . $this->content . '</tr>';
+		return '<tr class="bb-tag-tr">' . $this->getContent() . '</tr>';
 	}
 
     public function parse($arguments = [])

--- a/src/tag/BbUnderline.php
+++ b/src/tag/BbUnderline.php
@@ -16,6 +16,6 @@ class BbUnderline extends BbTag{
         $this->readContent();
     }
 	public function render() {
-		return '<ins class="onderstreept bb-tag-u">' . $this->content . '</ins>';
+		return '<ins class="onderstreept bb-tag-u">' . $this->getContent() . '</ins>';
 	}
 }

--- a/src/tag/Node.php
+++ b/src/tag/Node.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace CsrDelft\bb\tag;
+
+
+interface Node
+{
+    public function renderPlain();
+    public function renderLight();
+    public function render();
+    public function getChildren();
+
+    public function setContent($content);
+    public function getContent();
+
+    public function isAllowed();
+}

--- a/tests/TagsTest.php
+++ b/tests/TagsTest.php
@@ -1,20 +1,9 @@
 <?php
 
-namespace CsrDelft\bb\test;
-
 use CsrDelft\bb\DefaultParser;
-use PHPUnit\Framework\Assert;
+use CsrDelft\bb\test\VarDriverPlatformIndependent;
 use PHPUnit\Framework\TestCase;
-use Spatie\Snapshots\Drivers\VarDriver;
 use Spatie\Snapshots\MatchesSnapshots;
-
-class VarDriverPlatformIndependent extends VarDriver {
-    public function match($expected, $actual) {
-        $evaluated = eval(substr($expected, strlen('<?php ')));
-
-        Assert::assertEquals(str_replace("\r\n", "\n", $evaluated), str_replace("\r\n", "\n", $actual));
-    }
-}
 
 final class TagsTest extends TestCase
 {

--- a/tests/lib/VarDriverPlatformIndependent.php
+++ b/tests/lib/VarDriverPlatformIndependent.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace CsrDelft\bb\test;
+
+
+use PHPUnit\Framework\Assert;
+use Spatie\Snapshots\Drivers\VarDriver;
+
+class VarDriverPlatformIndependent extends VarDriver {
+    public function match($expected, $actual) {
+        $evaluated = eval(substr($expected, strlen('<?php ')));
+
+        Assert::assertEquals(str_replace("\r\n", "\n", $evaluated), str_replace("\r\n", "\n", $actual));
+    }
+}


### PR DESCRIPTION
First create a tree, then render the tree. This breaks some usages of readMainArgument.

Goal is creating the ability to pull another representation from the bb parser.